### PR TITLE
Fix profile name display

### DIFF
--- a/app/src/main/java/com/example/smartmed/MainScreen.kt
+++ b/app/src/main/java/com/example/smartmed/MainScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -28,9 +27,9 @@ import com.example.smartmed.graphs.MainNavGraph
 @Composable
 fun MainScreen(
     rootNavHostController: NavHostController,
-    homeNavController : NavHostController = rememberNavController()
+    homeNavController : NavHostController = rememberNavController(),
+    profileSharedViewModel: ProfileSharedViewModel
 ) {
-    val profileSharedViewModel: ProfileSharedViewModel = viewModel()
     val navBackStackEntry by homeNavController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
     Scaffold(
@@ -119,6 +118,7 @@ fun RowScope.AddItem(
 fun MainScreenPreview() {
     MainScreen(
         rootNavHostController = rememberNavController(),
-        homeNavController = rememberNavController()
+        homeNavController = rememberNavController(),
+        profileSharedViewModel = ProfileSharedViewModel()
     )
 }

--- a/app/src/main/java/com/example/smartmed/ProfileSharedViewModel.kt
+++ b/app/src/main/java/com/example/smartmed/ProfileSharedViewModel.kt
@@ -10,8 +10,16 @@ class ProfileSharedViewModel : ViewModel() {
     private val _profileImageUri = MutableStateFlow<String?>(null)
     val profileImageUri: StateFlow<String?> = _profileImageUri
 
+    private val _profileName = MutableStateFlow<String?>(null)
+    val profileName: StateFlow<String?> = _profileName
+
     fun setProfileImage(uri: String) {
         _profileImageUri.value = uri
+
+    }
+
+    fun setProfileName(name: String) {
+        _profileName.value = name
 
     }
 }

--- a/app/src/main/java/com/example/smartmed/authScreen/CreateProfile.kt
+++ b/app/src/main/java/com/example/smartmed/authScreen/CreateProfile.kt
@@ -295,6 +295,7 @@ fun ProfileScreen(navController: NavController,
         Button(
             onClick = {
                 viewModel.saveUserProfile(fullName, phoneNumber, selectedDate, onSuccess = {}, onFailure = {} )
+                viewSharedModel.setProfileName(fullName)
 
                 navController.navigate(Graph.MainScreenGraph){
                 popUpTo(AuthRouteScreen.ProfileScreen.route){

--- a/app/src/main/java/com/example/smartmed/bottomBarScreens/HomeScreen.kt
+++ b/app/src/main/java/com/example/smartmed/bottomBarScreens/HomeScreen.kt
@@ -57,7 +57,8 @@ fun HomeScreen(innerPadding: PaddingValues,
                healthTipsViewModel: HealthTipsViewModel
 ) {
 
-    val name = stringResource(id = R.string.name)
+    val defaultName = stringResource(id = R.string.name)
+    val name by profileSharedViewModel.profileName.collectAsState()
     var isLiked by remember { mutableStateOf(false) }
     val profileImageUri by profileSharedViewModel.profileImageUri.collectAsState()
 
@@ -109,7 +110,7 @@ fun HomeScreen(innerPadding: PaddingValues,
                         ),
                     )
                     Text(
-                        text = name,
+                        text = name ?: defaultName,
                         style = TextStyle(
                             fontSize = 14.sp, // Font size
                             fontWeight = FontWeight.Normal,
@@ -331,8 +332,11 @@ fun HealthTipCard(tip: HealthTip, viewModel: HealthTipsViewModel) {
 @Composable
 @Preview
 fun HomeScreenPreview() {
-    HomeScreen(innerPadding = PaddingValues(),
-               navController = rememberNavController(),
-               profileSharedViewModel = ProfileSharedViewModel(),
-                healthTipsViewModel = HealthTipsViewModel())
+    val shared = ProfileSharedViewModel().apply { setProfileName("Robin Hood") }
+    HomeScreen(
+        innerPadding = PaddingValues(),
+        navController = rememberNavController(),
+        profileSharedViewModel = shared,
+        healthTipsViewModel = HealthTipsViewModel()
+    )
 }

--- a/app/src/main/java/com/example/smartmed/graphs/RootNavGraph.kt
+++ b/app/src/main/java/com/example/smartmed/graphs/RootNavGraph.kt
@@ -26,7 +26,10 @@ fun  RootNavGraph(isAuth : Boolean) {
             profileSharedViewModel = profileSharedViewModel
             )
         composable(route = Graph.MainScreenGraph){
-            MainScreen(rootNavHostController = rootNavController)
+            MainScreen(
+                rootNavHostController = rootNavController,
+                profileSharedViewModel = profileSharedViewModel
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- store user name in `ProfileSharedViewModel`
- save profile name from `CreateProfile` screen
- read profile name in `HomeScreen`

## Testing
- `./gradlew test --no-daemon` *(fails: `/workspace/Med_Smart/local.properties (No such file or directory)`)*

------
https://chatgpt.com/codex/tasks/task_e_685b8b774254832eb5ae887692e741a3